### PR TITLE
Parallelization of parallel tempered chains

### DIFF
--- a/gbfisher/src/Makefile
+++ b/gbfisher/src/Makefile
@@ -6,7 +6,7 @@ CC = gcc
 LIBS  = gsl gslcblas m gbmcmc # fftw3
 LDFLAGS = -L../../gbmcmc/src
 #CCFLAGS += -g -ffast-math -Wall -O3 -ftree-vectorize -std=gnu99 -Werror
-CCFLAGS += -g -ffast-math -Wall -O3 -ftree-vectorize -std=gnu99
+CCFLAGS += -g -ffast-math -Wall -O3 -ftree-vectorize -std=gnu99 -fopenmp
 
 # Compile src with git hash
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)

--- a/gbmcmc/src/GalacticBinary.h
+++ b/gbmcmc/src/GalacticBinary.h
@@ -167,6 +167,7 @@ struct Flags
     int confNoise;  //!<`[--conf-noise; default=FALSE]`: include model of confusion noise in \f$S_n(f)\f$, either for simulating noise or as starting value for parameterized noise model.
     int resume;     //!<`[--resume; default=FALSE]`: restart sampler from run state saved during checkpointing. Starts from scratch if no checkpointing files are found.
     int catalog;    //!<`[--catalog=FILENAME; default=FALSE]`: use list of previously detected sources supplied in `FILENAME` to clean bandwidth padding (`gb_mcmc`) or for building family tree (`gb_catalog`).
+    int threads;
     ///@}
 
     

--- a/gbmcmc/src/GalacticBinaryIO.c
+++ b/gbmcmc/src/GalacticBinaryIO.c
@@ -59,7 +59,7 @@ void print_version(FILE *fptr)
     fprintf(fptr, "============== GBMCMC Version: =============\n\n");
     //fprintf(fptr, "  Git remote origin: %s\n", GIT_URL);
     //fprintf(fptr, "  Git version: %s\n", GIT_VER);
-    fprintf(fptr, "  Git commit: %s\n", GITVERSION);
+    fprintf(fptr, "  Git commit: %s\n", gitversion);
     //fprintf(fptr, "  Git commit author: %s\n",GIT_AUTHOR);
     //fprintf(fptr, "  Git commit date: %s\n", GIT_DATE);
 }

--- a/gbmcmc/src/GalacticBinaryIO.c
+++ b/gbmcmc/src/GalacticBinaryIO.c
@@ -317,6 +317,7 @@ void parse(int argc, char **argv, struct Data **data, struct Orbit *orbit, struc
     flags->NINJ        = 0;
     flags->simNoise    = 0;
     flags->confNoise   = 0;
+    flags->fixFdot     = 0;
     flags->fixSky      = 0;
     flags->fixFreq     = 0;
     flags->fixFdot     = 0;

--- a/gbmcmc/src/GalacticBinaryIO.c
+++ b/gbmcmc/src/GalacticBinaryIO.c
@@ -151,6 +151,7 @@ void print_run_settings(int argc, char **argv, struct Data *data_ptr, struct Orb
     fprintf(fptr,"  MCMC steps............%i   \n",flags->NMCMC);
     fprintf(fptr,"  MCMC burnin steps.....%i   \n",flags->NBURN);
     fprintf(fptr,"  MCMC chain seed ..... %li  \n",data_ptr->cseed);
+    fprintf(fptr,"  Number of threads ... %i   \n",flags->threads);
     fprintf(fptr,"\n");
     fprintf(fptr,"================= RUN FLAGS ================\n");
     if(flags->verbose)  fprintf(fptr,"  Verbose flag ........ ENABLED \n");
@@ -598,6 +599,11 @@ void parse(int argc, char **argv, struct Data **data, struct Orbit *orbit, struc
         exit(1);
     }
     
+    //Chains should be a multiple of threads for best usage of cores
+    if(chain->NC % flags->threads !=0){
+        chain->NC += flags->threads - (chain->NC % flags->threads);
+    }
+
     //pad data
     data[0]->N += 2*data[0]->qpad;
     data[0]->fmin -= data[0]->qpad/data[0]->T;

--- a/gbmcmc/src/GalacticBinaryIO.c
+++ b/gbmcmc/src/GalacticBinaryIO.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <omp.h>
 
 #include <gsl/gsl_sort.h>
 #include <gsl/gsl_statistics.h>
@@ -251,6 +252,7 @@ void print_usage()
     fprintf(stdout,"       --chainseed   : seed for MCMC RNG                   \n");
     fprintf(stdout,"       --chains      : number of parallel chains (20)      \n");
     fprintf(stdout,"       --no-burnin   : skip burn in steps                  \n");
+    fprintf(stdout,"       --threads     : number of threads to run parallel (number of cores)\n");
     fprintf(stdout,"\n");
     
     //Model
@@ -342,6 +344,7 @@ void parse(int argc, char **argv, struct Data **data, struct Orbit *orbit, struc
     flags->DMAX        = DMAX_default;
     flags->NMCMC       = 100000;
     flags->NBURN       = 100000;
+    flags->threads     = omp_get_max_threads();
     chain->NP          = 9; //number of proposals
     chain->NC          = 12;//number of chains
     
@@ -401,6 +404,7 @@ void parse(int argc, char **argv, struct Data **data, struct Orbit *orbit, struc
         {"steps",     required_argument, 0, 0},
         {"em-prior",  required_argument, 0, 0},
         {"catalog",   required_argument, 0, 0},
+        {"threads",   required_argument, 0, 0},
         
         /* These options don’t set a flag.
          We distinguish them by their indices. */
@@ -464,7 +468,8 @@ void parse(int argc, char **argv, struct Data **data, struct Orbit *orbit, struc
                 if(strcmp("no-rj",       long_options[long_index].name) == 0) flags->rj         = 0;
                 if(strcmp("fit-gap",     long_options[long_index].name) == 0) flags->gap        = 1;
                 if(strcmp("calibration", long_options[long_index].name) == 0) flags->calibration= 1;
-                if(strcmp("resume",      long_options[long_index].name) == 0) flags->resume=1;
+                if(strcmp("resume",      long_options[long_index].name) == 0) flags->resume     = 1;
+                if(strcmp("threads",     long_options[long_index].name) == 0) flags->threads    = atoi(optarg);
                 if(strcmp("duration",    long_options[long_index].name) == 0)
                 {   data_ptr->T   = (double)atof(optarg);
                     data_ptr->sqT = sqrt(data_ptr->T);

--- a/gbmcmc/src/GalacticBinaryMCMC.c
+++ b/gbmcmc/src/GalacticBinaryMCMC.c
@@ -345,16 +345,20 @@ int main(int argc, char *argv[])
     /* Write example gb_catalog bash script in run directory */
     print_gb_catalog_script(flags, data[0], orbit);
 
+    /* Temporary! Ask for thread count*/
     int threads;
     printf("How many threads to run: ");
     scanf("%d",&threads);
 
+    //For saving the number of threads actually given
     int numThreads;
     #pragma omp parallel num_threads(threads)
     {   
         int threadID;
+        //Save individual thread number
         threadID = omp_get_thread_num();
 
+        //Only one thread runs this section
         if(threadID==0){
             numThreads = omp_get_num_threads();
             printf("Got %i threads.\n",numThreads);
@@ -362,116 +366,120 @@ int main(int argc, char *argv[])
 
         #pragma omp barrier
 
-    /* The MCMC loop */    
-    for(int mcmc = mcmc_start; mcmc < flags->NMCMC; mcmc++)
-    {
-        if(mcmc<0) flags->burnin=1;
-        else       flags->burnin=0;
-        
-        //set annealinging tempurature during burnin
-        /*
-         if(flags->burnin)
-         {
-         chain->annealing = data[0]->SNR2*pow(data[0]->SNR2,-((double)mcmc+(double)flags->NBURN)/((double)flags->NBURN/(double)10))/40.;
-         if(chain->annealing<1.0)chain->annealing=1.0;
-         chain->annealing=1.0;
-         //printf("annealing=%g\n",chain->annealing);
-         }
-         */
-        chain->annealing=1.0;
-        
-        // (parallel) loop over chains
-        //#pragma omp parallel private(ic) shared(flags,model,trial,chain,orbit,proposal)
-        for(int ic=threadID; ic<NC; ic+=numThreads)
+        /* The MCMC loop */    
+        for(int mcmc = mcmc_start; mcmc < flags->NMCMC; mcmc++)
         {
-            
-            //loop over frequency segments
-            for(int i=0; i<flags->NDATA; i++)
+            if(mcmc<0) flags->burnin=1;
+            else       flags->burnin=0;
+        
+            //set annealinging tempurature during burnin
+            /*
+            if(flags->burnin)
+            {  
+            chain->annealing = data[0]->SNR2*pow(data[0]->SNR2,-((double)mcmc+(double)flags->NBURN)/((double)flags->NBURN/(double)10))/40.;
+            if(chain->annealing<1.0)chain->annealing=1.0;
+            chain->annealing=1.0;
+            //printf("annealing=%g\n",chain->annealing);
+            }
+            */
+            chain->annealing=1.0;
+        
+            // (parallel) loop over chains
+            for(int ic=threadID; ic<NC; ic+=numThreads)
             {
-                struct Model *model_ptr = model[chain->index[ic]][i];
-                struct Model *trial_ptr = trial[chain->index[ic]];
-                struct Data  *data_ptr  = data[i];
-                
-                
-                for(int steps=0; steps < 100; steps++)
+            
+                //loop over frequency segments
+                for(int i=0; i<flags->NDATA; i++)
                 {
-                    //for(int j=0; j<model_ptr->Nlive; j++)
-                    galactic_binary_mcmc(orbit, data_ptr, model_ptr, trial_ptr, chain, flags, prior, proposal[i], ic);
+                    struct Model *model_ptr = model[chain->index[ic]][i];
+                    struct Model *trial_ptr = trial[chain->index[ic]];
+                    struct Data  *data_ptr  = data[i];
+                
+                
+                    for(int steps=0; steps < 100; steps++)
+                    {
+                        //for(int j=0; j<model_ptr->Nlive; j++)
+                        galactic_binary_mcmc(orbit, data_ptr, model_ptr, trial_ptr, chain, flags, prior, proposal[i], ic);
 
-                    if(flags->strainData || flags->simNoise)
-                        noise_model_mcmc(orbit, data_ptr, model_ptr, trial_ptr, chain, flags, ic);
+                        if(flags->strainData || flags->simNoise)
+                            noise_model_mcmc(orbit, data_ptr, model_ptr, trial_ptr, chain, flags, ic);
                     
-                }//loop over MCMC steps
+                    }//loop over MCMC steps
 
-                //reverse jump birth/death move
-                if(flags->rj)galactic_binary_rjmcmc(orbit, data_ptr, model_ptr, trial_ptr, chain, flags, prior, proposal[i], ic);
+                    //reverse jump birth/death move
+                    if(flags->rj)galactic_binary_rjmcmc(orbit, data_ptr, model_ptr, trial_ptr, chain, flags, prior, proposal[i], ic);
                 
-                //update fisher matrix for each chain
-                if(mcmc%100==0)
-                {
-                    for(int n=0; n<model_ptr->Nlive; n++)
+                    //update fisher matrix for each chain
+                    if(mcmc%100==0)
                     {
-                        galactic_binary_fisher(orbit, data_ptr, model_ptr->source[n], data_ptr->noise[FIXME]);
+                        for(int n=0; n<model_ptr->Nlive; n++)
+                        {
+                            galactic_binary_fisher(orbit, data_ptr, model_ptr->source[n], data_ptr->noise[FIXME]);
+                        }
                     }
-                }
-            }//end loop over frequency segments
+                }//end loop over frequency segments
             
-            //update start time for data segments
-            if(flags->gap) data_mcmc(orbit, data, model[chain->index[ic]], chain, flags, proposal[0], ic);
+                //update start time for data segments
+                if(flags->gap) data_mcmc(orbit, data, model[chain->index[ic]], chain, flags, proposal[0], ic);
             
-        }// end (parallel) loop over chains
+            }// end (parallel) loop over chains
 
-        #pragma omp barrier
-        if(threadID==0){
-            ptmcmc(model,chain,flags);
-            adapt_temperature_ladder(chain, mcmc+flags->NBURN);
+            //Next section is single threaded. Every thread must get here before continuing
+            #pragma omp barrier
+            if(threadID==0){
+                ptmcmc(model,chain,flags);
+                adapt_temperature_ladder(chain, mcmc+flags->NBURN);
         
-            print_chain_files(data[FIXME], model, chain, flags, mcmc);
+                print_chain_files(data[FIXME], model, chain, flags, mcmc);
         
-            //track maximum log Likelihood
-            if(mcmc%100)
-            {
-                if(update_max_log_likelihood(model, chain, flags)) mcmc = -flags->NBURN;
-            }
+                //track maximum log Likelihood
+                if(mcmc%100)
+                {
+                    if(update_max_log_likelihood(model, chain, flags)) mcmc = -flags->NBURN;
+                }
         
-            //store reconstructed waveform
-            if(!flags->quiet) print_waveform_draw(data, model[chain->index[0]], flags);
+                //store reconstructed waveform
+                if(!flags->quiet) print_waveform_draw(data, model[chain->index[0]], flags);
         
-            //update run status
-            if(mcmc%data[FIXME]->downsample==0)
-            {
+                //update run status
+                if(mcmc%data[FIXME]->downsample==0)
+                {  
             
-                if(!flags->quiet)
+                    if(!flags->quiet)
+                    {
+                        for(int i=0; i<flags->NDATA; i++)
+                        {
+                            print_chain_state(data[i], chain, model[chain->index[0]][i], flags, stdout, mcmc); //writing to file
+                            fprintf(stdout,"Sources: %i\n",model[chain->index[0]][i]->Nlive);
+                            print_acceptance_rates(proposal[i], chain->NP, 0, stdout);
+                        }
+                    }
+            
+                    //save chain state to resume sampler
+                    save_chain_state(data, model, chain, flags, mcmc);
+            
+                }
+        
+                //dump waveforms to file, update avgLogL for thermodynamic integration
+                if(mcmc>0 && mcmc%data[FIXME]->downsample==0)
                 {
                     for(int i=0; i<flags->NDATA; i++)
+                        save_waveforms(data[i], model[chain->index[0]][i], mcmc/data[i]->downsample);
+                    
+                    for(int ic=0; ic<NC; ic++)
                     {
-                        print_chain_state(data[i], chain, model[chain->index[0]][i], flags, stdout, mcmc); //writing to file
-                        fprintf(stdout,"Sources: %i\n",model[chain->index[0]][i]->Nlive);
-                        print_acceptance_rates(proposal[i], chain->NP, 0, stdout);
+                        chain->dimension[ic][model[chain->index[ic]][0]->Nlive]++;
+                        for(int i=0; i<flags->NDATA; i++)
+                            chain->avgLogL[ic] += model[chain->index[ic]][i]->logL + model[chain->index[ic]][i]->logLnorm;
                     }
                 }
-            
-                //save chain state to resume sampler
-                save_chain_state(data, model, chain, flags, mcmc);
-            
             }
-        
-            //dump waveforms to file, update avgLogL for thermodynamic integration
-            if(mcmc>0 && mcmc%data[FIXME]->downsample==0)
-            {
-                for(int i=0; i<flags->NDATA; i++)save_waveforms(data[i], model[chain->index[0]][i], mcmc/data[i]->downsample);
-                for(int ic=0; ic<NC; ic++)
-                {
-                    chain->dimension[ic][model[chain->index[ic]][0]->Nlive]++;
-                    for(int i=0; i<flags->NDATA; i++)
-                        chain->avgLogL[ic] += model[chain->index[ic]][i]->logL + model[chain->index[ic]][i]->logLnorm;
-                }
-            }
-        }
-        #pragma omp barrier
-    }// end MCMC loop
+            //Can't continue MCMC until single thread is finished
+            #pragma omp barrier
+            
+        }// end MCMC loop
 
-    }
+    }// End of parallelization
     
     //print aggregate run files/results
     for(int i=0; i<flags->NDATA; i++)print_waveforms_reconstruction(data[i],i);

--- a/gbmcmc/src/GalacticBinaryMCMC.c
+++ b/gbmcmc/src/GalacticBinaryMCMC.c
@@ -345,18 +345,18 @@ int main(int argc, char *argv[])
     /* Write example gb_catalog bash script in run directory */
     print_gb_catalog_script(flags, data[0], orbit);
 
-    
+    /*
     // Temporary! Ask for thread count
     int threads;
     printf("How many threads to run: ");
     scanf("%d",&threads);
-    
-
+    */
+    omp_get_max_threads();
 
     //For saving the number of threads actually given
     int numThreads;
     int mcmc = mcmc_start;
-    #pragma omp parallel //num_threads(threads)
+    #pragma omp parallel num_threads(flags->threads)//num_threads(threads)
     {   
         int threadID;
         //Save individual thread number
@@ -365,7 +365,7 @@ int main(int argc, char *argv[])
         //Only one thread runs this section
         if(threadID==0){
             numThreads = omp_get_num_threads();
-            printf("Got %i threads.\n",numThreads);
+            printf("Running on %i thread(s).\n",numThreads);
         }
 
         #pragma omp barrier
@@ -504,9 +504,9 @@ int main(int argc, char *argv[])
     //print total run time
     stop = time(NULL);
     
-    printf(" ELAPSED TIME = %g second\n",(double)(stop-start));
+    printf(" ELAPSED TIME = %g seconds on %i thread(s)\n",(double)(stop-start),numThreads);
     FILE *runlog = fopen("gb_mcmc.log","a");
-    fprintf(runlog," ELAPSED TIME = %g second\n",(double)(stop-start));
+    fprintf(runlog," ELAPSED TIME = %g seconds on %i thread(s)\n",(double)(stop-start),numThreads);
     fclose(runlog);
     
     //free memory and exit cleanly

--- a/gbmcmc/src/GalacticBinaryMCMC.c
+++ b/gbmcmc/src/GalacticBinaryMCMC.c
@@ -345,14 +345,17 @@ int main(int argc, char *argv[])
     /* Write example gb_catalog bash script in run directory */
     print_gb_catalog_script(flags, data[0], orbit);
 
-    /* Temporary! Ask for thread count*/
+    /*
+    // Temporary! Ask for thread count
     int threads;
     printf("How many threads to run: ");
     scanf("%d",&threads);
+    */
+
 
     //For saving the number of threads actually given
     int numThreads;
-    #pragma omp parallel num_threads(threads)
+    #pragma omp parallel //num_threads(threads)
     {   
         int threadID;
         //Save individual thread number
@@ -369,21 +372,25 @@ int main(int argc, char *argv[])
         /* The MCMC loop */    
         for(int mcmc = mcmc_start; mcmc < flags->NMCMC; mcmc++)
         {
-            if(mcmc<0) flags->burnin=1;
-            else       flags->burnin=0;
-        
-            //set annealinging tempurature during burnin
-            /*
-            if(flags->burnin)
-            {  
-            chain->annealing = data[0]->SNR2*pow(data[0]->SNR2,-((double)mcmc+(double)flags->NBURN)/((double)flags->NBURN/(double)10))/40.;
-            if(chain->annealing<1.0)chain->annealing=1.0;
-            chain->annealing=1.0;
-            //printf("annealing=%g\n",chain->annealing);
+            if(threadID==0){
+                if(mcmc<0) flags->burnin=1;
+                else       flags->burnin=0;
+
+                //set annealinging tempurature during burnin
+                /*
+                if(flags->burnin)
+                {  
+                chain->annealing = data[0]->SNR2*pow(data[0]->SNR2,-((double)mcmc+(double)flags->NBURN)/((double)flags->NBURN/(double)10))/40.;
+                if(chain->annealing<1.0)chain->annealing=1.0;
+                chain->annealing=1.0;
+                //printf("annealing=%g\n",chain->annealing);
+                }
+                */
+
+                chain->annealing=1.0;
             }
-            */
-            chain->annealing=1.0;
-        
+
+            #pragma omp barrier
             // (parallel) loop over chains
             for(int ic=threadID; ic<NC; ic+=numThreads)
             {

--- a/gbmcmc/src/GalacticBinaryMCMC.c
+++ b/gbmcmc/src/GalacticBinaryMCMC.c
@@ -345,16 +345,17 @@ int main(int argc, char *argv[])
     /* Write example gb_catalog bash script in run directory */
     print_gb_catalog_script(flags, data[0], orbit);
 
-    /*
+    
     // Temporary! Ask for thread count
     int threads;
     printf("How many threads to run: ");
     scanf("%d",&threads);
-    */
+    
 
 
     //For saving the number of threads actually given
     int numThreads;
+    int mcmc = mcmc_start;
     #pragma omp parallel //num_threads(threads)
     {   
         int threadID;
@@ -370,7 +371,7 @@ int main(int argc, char *argv[])
         #pragma omp barrier
 
         /* The MCMC loop */    
-        for(int mcmc = mcmc_start; mcmc < flags->NMCMC; mcmc++)
+        for(; mcmc < flags->NMCMC;)
         {
             if(threadID==0){
                 if(mcmc<0) flags->burnin=1;
@@ -480,6 +481,7 @@ int main(int argc, char *argv[])
                             chain->avgLogL[ic] += model[chain->index[ic]][i]->logL + model[chain->index[ic]][i]->logLnorm;
                     }
                 }
+                mcmc++;
             }
             //Can't continue MCMC until single thread is finished
             #pragma omp barrier

--- a/gbmcmc/src/Makefile
+++ b/gbmcmc/src/Makefile
@@ -37,7 +37,7 @@ GalacticBinaryPrior.o : GalacticBinaryPrior.c GalacticBinaryPrior.h GalacticBina
 	$(CC) $(CCFLAGS) -c GalacticBinaryPrior.c $(INCDIR:%=-I%) $(LIBDIR:%=-L%)
 
 GalacticBinaryData.o : GalacticBinaryData.c GalacticBinaryData.h GalacticBinary.h GalacticBinaryModel.o GalacticBinaryMath.o GalacticBinaryIO.o LISA.o 
-	 $(CC) $(CCFLAGS) -c GalacticBinaryData.c $(INCDIR:%=-I%) $(LIBDIR:%=-L%)
+	$(CC) $(CCFLAGS) -c GalacticBinaryData.c $(INCDIR:%=-I%) $(LIBDIR:%=-L%)
 
 GalacticBinaryWaveform.o : GalacticBinaryWaveform.c GalacticBinaryWaveform.h GalacticBinaryMath.o Constants.h LISA.o 
 	$(CC) $(CCFLAGS) -c GalacticBinaryWaveform.c $(INCDIR:%=-I%) $(LIBDIR:%=-L%)

--- a/gbmcmc/src/Makefile
+++ b/gbmcmc/src/Makefile
@@ -7,7 +7,7 @@ CC = gcc
 #LIBS  = gsl gslcblas m fftw3
 LIBS  = gsl gslcblas m tools
 LDFLAGS = -L../../tools/src
-CCFLAGS += -O3 -g -ffast-math -Wall -ftree-vectorize -std=gnu99 -Werror
+CCFLAGS += -O3 -g -ffast-math -Wall -ftree-vectorize -std=gnu99 -fopenmp -Werror
 
 # Compile src with git hash
 GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)


### PR DESCRIPTION
Based on the tests I've conducted the OpenMP implementation of multi-threading results in a nearly linear decrease to run time with increasing thread/core count.

I was not able to install with CMake, but I was able to install with an older method before I rebased off master. There could still be bugs and should be tested first to ensure reliability. 

To use multiple threads, you can specify the number at run time using the '--threads=' argument. Otherwise, it will default to OpenMP's default setting for the machine, which is usually the logical processor count. 