### PR TITLE
Pull correct imported target from MBH cmake package.

### DIFF
--- a/globalfit/src/CMakeLists.txt
+++ b/globalfit/src/CMakeLists.txt
@@ -1,8 +1,4 @@
 
-#MBH library
-#include_directories(/Users/tyson/temp/include)
-#link_directories(/Users/tyson/temp/lib)
-
 #GBMCMC library
 include_directories ("${PROJECT_SOURCE_DIR}/tools/src/")              
 include_directories ("${PROJECT_SOURCE_DIR}/lisa/src/")
@@ -18,7 +14,7 @@ target_link_libraries(global_fit lisa)
 target_link_libraries(global_fit gbmcmc)
 target_link_libraries(global_fit noise)
 target_link_libraries(global_fit mpi)
-target_link_libraries(global_fit mbh)
+target_link_libraries(global_fit MBH::mbh)
 if(APPLE)
    target_link_libraries(global_fit omp)
 endif()


### PR DESCRIPTION
This change depends on the MBH change to export the include directory in order for the build to work; however, it fixes an underlying bug in the invocation of target_link_libraries.

The pull request to MBH is here: https://github.com/eXtremeGravityInstitute/LISA-Massive-Black-Hole/pull/5
I have not tested on OSX, but this works on linux. I believe the mechanism below is sufficiently cmake-centric that I expect it to work correctly on OSX.

Bug that is fixed:
MBH is written such that it exports cmake variables under the prefix "MBH::" Before this change I believe cmake was finding MBH via some system wide configuration or the commented out lines removed in this change.

Paired with the change to MBH this "just works" and cmake finds MBH's include and lib directories through MBH's exported .cmake file in the way that is normal for cmake.